### PR TITLE
Fix glob pattern.

### DIFF
--- a/src/main/java/wrm/CompilationMojo.java
+++ b/src/main/java/wrm/CompilationMojo.java
@@ -80,7 +80,7 @@ public class CompilationMojo extends AbstractMojo {
 		getLog().debug("Output Path=" + outputPath); 
 		
 		final Path root = Paths.get(inputPath);
-		String globPattern = "glob:"+inputPath+"**/*.scss";
+		String globPattern = "glob:"+inputPath+"{**/,}*.scss";
 		getLog().debug("Glob = " + globPattern);
 		final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(globPattern);
 		try {


### PR DESCRIPTION
Now `*.scss` files can be placed directly inside of the input path.