### PR TITLE
Better build scripts for libsass on linux and osx

### DIFF
--- a/make-libsass-darwin.sh
+++ b/make-libsass-darwin.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cd src/libsass;
+
+autoreconf --force --install
+
+./configure --disable-tests --enable-shared 
+
+make -j5
+
+cd ..;
+
+cp libsass/.libs/libsass.0.dylib main/resources/darwin/libsass.dylib
+cd ..;

--- a/make-libsass-linux-x86-64.sh
+++ b/make-libsass-linux-x86-64.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
 cd src;
-BUILD="shared" make -C libsass;
+
+# We use:
+# - BUILD="shared" to make sure that we build a shared system library
+# - CXX=g++-4.6 to make sure that the library is linked against a version of 
+#               libstdc++.so.6 that is old enough to be widely compatible
+# - CC=gcc-4.4  same as for CXX but for libc.so.6
+BUILD="shared" make -C libsass CXX=g++-4.6 CC=gcc-4.4;
+
 cp libsass/lib/libsass.so main/resources/linux-x86-64
 cd ..;


### PR DESCRIPTION
- Added a proper build script to compiler libsass correctly on osx
- Updated the build script for libsass on linux to link with a version of libstc++ that is as old as possible (for compatibility reasons)