### PR TITLE
upgrade JSass to 4.1.0 (libsass 3.3.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>io.bit3</groupId>
 			<artifactId>jsass</artifactId>
-			<version>4.0.2</version>
+			<version>4.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/src/test/java/test/SassCompilerTest.java
+++ b/src/test/java/test/SassCompilerTest.java
@@ -115,7 +115,7 @@ public class SassCompilerTest {
 		compiler.setOutputStyle(OutputStyle.COMPRESSED);
 		compile("/precision.scss");
 
-		assertCssContains(".something{padding:0 0.8em 0.71429 0.8em}");
+		assertCssContains(".something{padding:0 0.8em .71429 0.8em}");
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class SassCompilerTest {
 		compiler.setPrecision(10);
 		compile("/precision.scss");
 
-		assertCssContains(".something{padding:0 0.8em 0.7142857143 0.8em}");
+		assertCssContains(".something{padding:0 0.8em .7142857143 0.8em}");
 	}
 
 	private void compile(String file) throws Exception {


### PR DESCRIPTION
Hi,

JSass just released an upgraded version, which is now equal to the latest version of libsass.
Please take a look at the second commit, because I had to change two test assert a little. I think they are still valid. Libsass seams to have started to remove leading zeros. 