### PR TITLE
Update jsass to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>io.bit3</groupId>
 			<artifactId>jsass</artifactId>
-			<version>4.1.0</version>
+			<version>5.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/src/main/java/wrm/CompilationMojo.java
+++ b/src/main/java/wrm/CompilationMojo.java
@@ -256,14 +256,6 @@ public class CompilationMojo extends AbstractMojo {
 			return false;
 		}
 
-		if (out.getErrorStatus() != 0) {
-			getLog().error(out.getErrorMessage());
-			getLog().debug("ErrorText: " + out.getErrorText());
-			getLog().debug("ErrorFile: " + out.getErrorFile());
-			getLog().debug("ErrorJson: " + out.getErrorJson());
-			return false;
-		}
-
 		getLog().debug("Compilation finished.");
 
 		writeContentToFile(outputFilePath, out.getCss());


### PR DESCRIPTION
Fixes #35 

JSass has stopped returning status codes and only throws CompilationExceptions now.


