### PR TITLE
Issue No.37,  Fix to allow Input / output path with spaces

### DIFF
--- a/src/main/java/wrm/libsass/SassCompiler.java
+++ b/src/main/java/wrm/libsass/SassCompiler.java
@@ -31,8 +31,11 @@ public class SassCompiler {
 
 	) throws CompilationException {
 
-		URI inputFile = new File(inputPathAbsolute).toURI();
-		URI outputFile = new File(outputPathRelativeToInput).toURI();
+		String inputOmitSpace = inputPathAbsolute.replaceAll("%20", " ");
+		String outputOmitSpace = outputPathRelativeToInput.replaceAll("%20", " ");
+
+		URI inputFile = new File(inputOmitSpace).toURI();
+		URI outputFile = new File(outputOmitSpace).toURI();
 
 		Options opt = getConfiguredOptions(inputPathAbsolute, sourceMapPathRelativeToInput);
 


### PR DESCRIPTION
This would allow folder name contain space inside the path of the input or output folder