### PR TITLE
Adding watch goal to trigger a compile when there are changes

### DIFF
--- a/src/main/java/wrm/AbstractSassMojo.java
+++ b/src/main/java/wrm/AbstractSassMojo.java
@@ -1,0 +1,254 @@
+package wrm;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.project.MavenProject;
+
+import io.bit3.jsass.CompilationException;
+import io.bit3.jsass.Output;
+import wrm.libsass.SassCompiler;
+
+public abstract class AbstractSassMojo extends AbstractMojo {
+
+	/**
+	 * The directory in which the compiled CSS files will be placed. The default value is
+	 * <tt>${project.build.directory}</tt>
+	 *
+	 * @parameter property="project.build.directory"
+	 * @required
+	 */
+	protected File outputPath;
+	/**
+	 * The directory from which the source .scss files will be read. This directory will be
+	 * traversed recursively, and all .scss files found in this directory or subdirectories
+	 * will be compiled. The default value is <tt>src/main/sass</tt>
+	 *
+	 * @parameter default-value="src/main/sass"
+	 */
+	protected String inputPath;
+	/**
+	 * Additional include path, ';'-separated. The default value is <tt>null</tt>
+	 *
+	 * @parameter
+	 */
+	private String includePath;
+	/**
+	 * Output style for the generated css code. One of <tt>nested</tt>, <tt>expanded</tt>,
+	 * <tt>compact</tt>, <tt>compressed</tt>. Note that as of libsass 3.1, <tt>expanded</tt>
+	 * and <tt>compact</tt> are the same as <tt>nested</tt>. The default value is
+	 * <tt>expanded</tt>.
+	 *
+	 * @parameter default-value="expanded"
+	 */
+	private SassCompiler.OutputStyle outputStyle;
+	/**
+	 * Emit comments in the compiled CSS indicating the corresponding source line. The default
+	 * value is <tt>false</tt>
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean generateSourceComments;
+	/**
+	 * Generate source map files. The generated source map files will be placed in the directory
+	 * specified by <tt>sourceMapOutputPath</tt>. The default value is <tt>true</tt>.
+	 *
+	 * @parameter default-value="true"
+	 */
+	private boolean generateSourceMap;
+	/**
+	 * The directory in which the source map files that correspond to the compiled CSS will be
+	 * placed. The default value is <tt>${project.build.directory}</tt>
+	 *
+	 * @parameter property="project.build.directory"
+	 */
+	private String sourceMapOutputPath;
+	/**
+	 * Prevents the generation of the <tt>sourceMappingURL</tt> special comment as the last
+	 * line of the compiled CSS. The default value is <tt>false</tt>.
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean omitSourceMapingURL;
+	/**
+	 * Embeds the whole source map data directly into the compiled CSS file by transforming
+	 * <tt>sourceMappingURL</tt> into a data URI. The default value is <tt>false</tt>.
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean embedSourceMapInCSS;
+	/**
+	 * Embeds the contents of the source .scss files in the source map file instead of the
+	 * paths to those files. The default value is <tt>false</tt>
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean embedSourceContentsInSourceMap;
+	/**
+	 * Switches the input syntax used by the files to either <tt>sass</tt> or <tt>scss</tt>.
+	 * The default value is <tt>scss</tt>.
+	 *
+	 * @parameter default-value="scss"
+	 */
+	private SassCompiler.InputSyntax inputSyntax;
+	/**
+	 * Precision for fractional numbers. The default value is <tt>5</tt>.
+	 *
+	 * @parameter default-value="5"
+	 */
+	private int precision;
+	/**
+	 * should fail the build in case of compilation errors.
+	 *
+	 * @parameter default-value="true"
+	 */
+	protected boolean failOnError;
+	/**
+	 * @parameter property="project"
+	 * @required
+	 * @readonly
+	 */
+	protected MavenProject project;
+	protected SassCompiler compiler;
+
+	public AbstractSassMojo() {
+		super();
+	}
+
+	protected String getFileExtension() {
+		return inputSyntax.toString();
+	}
+
+	protected void validateConfig() {
+		if (!generateSourceMap) {
+			if (embedSourceMapInCSS) {
+				getLog().warn("embedSourceMapInCSS=true is ignored. Cause: generateSourceMap=false");
+			}
+			if (embedSourceContentsInSourceMap) {
+				getLog().warn("embedSourceContentsInSourceMap=true is ignored. Cause: generateSourceMap=false");
+			}
+		}
+		if (outputStyle != SassCompiler.OutputStyle.compressed && outputStyle != SassCompiler.OutputStyle.nested) {
+			getLog().warn("outputStyle=" + outputStyle + " is replaced by nested. Cause: libsass 3.1 only supports compressed and nested");
+		}
+	}
+
+	protected SassCompiler initCompiler() {
+		SassCompiler compiler = new SassCompiler();
+		compiler.setEmbedSourceMapInCSS(this.embedSourceMapInCSS);
+		compiler.setEmbedSourceContentsInSourceMap(this.embedSourceContentsInSourceMap);
+		compiler.setGenerateSourceComments(this.generateSourceComments);
+		compiler.setGenerateSourceMap(this.generateSourceMap);
+		compiler.setIncludePaths(this.includePath);
+		compiler.setInputSyntax(this.inputSyntax);
+		compiler.setOmitSourceMappingURL(this.omitSourceMapingURL);
+		compiler.setOutputStyle(this.outputStyle);
+		compiler.setPrecision(this.precision);
+		return compiler;
+	}
+
+	protected boolean processFile(Path inputRootPath, Path inputFilePath) throws IOException {
+		getLog().debug("Processing File " + inputFilePath);
+	
+		Path relativeInputPath = inputRootPath.relativize(inputFilePath);
+	
+		Path outputRootPath = this.outputPath.toPath();
+		Path outputFilePath = outputRootPath.resolve(relativeInputPath);
+		String fileExtension = getFileExtension();
+		outputFilePath = Paths.get(outputFilePath.toAbsolutePath().toString().replaceFirst("\\."+fileExtension+"$", ".css"));
+	
+		Path sourceMapRootPath = Paths.get(this.sourceMapOutputPath);
+		Path sourceMapOutputPath = sourceMapRootPath.resolve(relativeInputPath);
+		sourceMapOutputPath = Paths.get(sourceMapOutputPath.toAbsolutePath().toString().replaceFirst("\\.scss$", ".css.map"));
+	
+	
+		Output out;
+		try {
+			out = compiler.compileFile(
+					inputFilePath.toAbsolutePath().toString(),
+					outputFilePath.toAbsolutePath().toString(),
+					sourceMapOutputPath.toAbsolutePath().toString()
+			);
+		}
+		catch (CompilationException e) {
+			getLog().error(e.getMessage());
+			getLog().debug(e);
+			return false;
+		}
+	
+		getLog().debug("Compilation finished.");
+	
+		writeContentToFile(outputFilePath, out.getCss());
+		if (out.getSourceMap() != null) {
+			writeContentToFile(sourceMapOutputPath, out.getSourceMap());
+		}
+		return true;
+	}
+
+	private void writeContentToFile(Path outputFilePath, String content) throws IOException {
+		File f = outputFilePath.toFile();
+		f.getParentFile().mkdirs();
+		f.createNewFile();
+		OutputStreamWriter os = null;
+		try{
+			os = new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
+			os.write(content);
+			os.flush();
+		} finally {
+			if (os != null)
+				os.close();
+		}
+		getLog().debug("Written to: " + f);
+	}
+
+	protected void compile() throws Exception {
+		final Path root = project.getBasedir().toPath().resolve(Paths.get(inputPath));
+		String fileExt = getFileExtension();
+		String globPattern = "glob:{**/,}*."+fileExt;
+		getLog().debug("Glob = " + globPattern);
+	
+		final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(globPattern);
+		final AtomicInteger errorCount = new AtomicInteger(0);
+		final AtomicInteger fileCount = new AtomicInteger(0);
+		Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				if (matcher.matches(file) && !file.getFileName().toString().startsWith("_")) {
+					fileCount.incrementAndGet();
+					if(!processFile(root, file)){
+						errorCount.incrementAndGet();
+					}
+				}
+	
+				return FileVisitResult.CONTINUE;
+			}
+	
+			@Override
+			public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	
+		getLog().info("Compiled " + fileCount + " files");
+		if (errorCount.get() > 0) {
+			if (failOnError) {
+				throw new Exception("Failed with " + errorCount.get() + " errors");
+			} else {
+				getLog().error("Failed with " + errorCount.get() + " errors. Continuing due to failOnError=false.");
+			}
+		}
+	}
+
+}

--- a/src/main/java/wrm/CompilationMojo.java
+++ b/src/main/java/wrm/CompilationMojo.java
@@ -1,27 +1,7 @@
 package wrm;
 
-import io.bit3.jsass.CompilationException;
-import io.bit3.jsass.Output;
-import wrm.libsass.SassCompiler;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
 
 /**
  * Compilation of all scss files from inputpath to outputpath using includePaths
@@ -29,120 +9,7 @@ import org.apache.maven.project.MavenProject;
  * @goal compile
  * @phase generate-resources
  */
-public class CompilationMojo extends AbstractMojo {
-	/**
-	 * The directory in which the compiled CSS files will be placed. The default value is
-	 * <tt>${project.build.directory}</tt>
-	 *
-	 * @parameter property="project.build.directory"
-	 * @required
-	 */
-	private File outputPath;
-
-	/**
-	 * The directory from which the source .scss files will be read. This directory will be
-	 * traversed recursively, and all .scss files found in this directory or subdirectories
-	 * will be compiled. The default value is <tt>src/main/sass</tt>
-	 *
-	 * @parameter default-value="src/main/sass"
-	 */
-	private String inputPath;
-
-	/**
-	 * Additional include path, ';'-separated. The default value is <tt>null</tt>
-	 *
-	 * @parameter
-	 */
-	private String includePath;
-
-	/**
-	 * Output style for the generated css code. One of <tt>nested</tt>, <tt>expanded</tt>,
-	 * <tt>compact</tt>, <tt>compressed</tt>. Note that as of libsass 3.1, <tt>expanded</tt>
-	 * and <tt>compact</tt> are the same as <tt>nested</tt>. The default value is
-	 * <tt>expanded</tt>.
-	 *
-	 * @parameter default-value="expanded"
-	 */
-	private SassCompiler.OutputStyle outputStyle;
-
-	/**
-	 * Emit comments in the compiled CSS indicating the corresponding source line. The default
-	 * value is <tt>false</tt>
-	 *
-	 * @parameter default-value="false"
-	 */
-	private boolean generateSourceComments;
-
-	/**
-	 * Generate source map files. The generated source map files will be placed in the directory
-	 * specified by <tt>sourceMapOutputPath</tt>. The default value is <tt>true</tt>.
-	 *
-	 * @parameter default-value="true"
-	 */
-	private boolean generateSourceMap;
-
-	/**
-	 * The directory in which the source map files that correspond to the compiled CSS will be
-	 * placed. The default value is <tt>${project.build.directory}</tt>
-	 *
-	 * @parameter property="project.build.directory"
-	 */
-	private String sourceMapOutputPath;
-
-	/**
-	 * Prevents the generation of the <tt>sourceMappingURL</tt> special comment as the last
-	 * line of the compiled CSS. The default value is <tt>false</tt>.
-	 *
-	 * @parameter default-value="false"
-	 */
-	private boolean omitSourceMapingURL;
-
-	/**
-	 * Embeds the whole source map data directly into the compiled CSS file by transforming
-	 * <tt>sourceMappingURL</tt> into a data URI. The default value is <tt>false</tt>.
-	 *
-	 * @parameter default-value="false"
-	 */
-	private boolean embedSourceMapInCSS;
-
-	/**
-	 * Embeds the contents of the source .scss files in the source map file instead of the
-	 * paths to those files. The default value is <tt>false</tt>
-	 *
-	 * @parameter default-value="false"
-	 */
-	private boolean embedSourceContentsInSourceMap;
-
-	/**
-	 * Switches the input syntax used by the files to either <tt>sass</tt> or <tt>scss</tt>.
-	 * The default value is <tt>scss</tt>.
-	 *
-	 * @parameter default-value="scss"
-	 */
-	private SassCompiler.InputSyntax inputSyntax;
-
-	/**
-	 * Precision for fractional numbers. The default value is <tt>5</tt>.
-	 *
-	 * @parameter default-value="5"
-	 */
-	private int precision;
-
-	/**
-	 * should fail the build in case of compilation errors.
-	 *
-	 * @parameter default-value="true"
-	 */
-	private boolean failOnError;
-
-	/**
-	 * @parameter property="project"
-	 * @required
-	 * @readonly
-	 */
-	protected MavenProject project;
-
-	private SassCompiler compiler;
+public class CompilationMojo extends AbstractSassMojo {
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		validateConfig();
@@ -152,132 +19,12 @@ public class CompilationMojo extends AbstractMojo {
 
 		getLog().debug("Input Path=" + inputPath);
 		getLog().debug("Output Path=" + outputPath);
-
-		final Path root = project.getBasedir().toPath().resolve(Paths.get(inputPath));
-		String fileExt = getFileExtension();
-		String globPattern = "glob:{**/,}*."+fileExt;
-		getLog().debug("Glob = " + globPattern);
-
-		final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(globPattern);
-		final AtomicInteger errorCount = new AtomicInteger(0);
-		final AtomicInteger fileCount = new AtomicInteger(0);
+		
 		try {
-			Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
-				@Override
-				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					if (matcher.matches(file) && !file.getFileName().toString().startsWith("_")) {
-						fileCount.incrementAndGet();
-						if(!processFile(root, file)){
-							errorCount.incrementAndGet();
-						}
-					}
-
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-					return FileVisitResult.CONTINUE;
-				}
-			});
-		}
-		catch (IOException e) {
+			compile();
+		} catch (Exception e) {
 			throw new MojoExecutionException("Failed", e);
 		}
-
-		getLog().info("Compiled " + fileCount + " files");
-		if(errorCount.get() > 0){
-			if (failOnError){
-				throw new MojoExecutionException("Failed with " + errorCount.get() + " errors");
-			} else {
-				getLog().error("Failed with " + errorCount.get() + " errors. Continuing due to failOnError=false.");
-			}
-		}
 	}
 
-	private String getFileExtension() {
-		return inputSyntax.toString();
-	}
-
-	private void validateConfig() {
-		if (!generateSourceMap) {
-			if (embedSourceMapInCSS) {
-				getLog().warn("embedSourceMapInCSS=true is ignored. Cause: generateSourceMap=false");
-			}
-			if (embedSourceContentsInSourceMap) {
-				getLog().warn("embedSourceContentsInSourceMap=true is ignored. Cause: generateSourceMap=false");
-			}
-		}
-		if (outputStyle != SassCompiler.OutputStyle.compressed && outputStyle != SassCompiler.OutputStyle.nested) {
-			getLog().warn("outputStyle=" + outputStyle + " is replaced by nested. Cause: libsass 3.1 only supports compressed and nested");
-		}
-	}
-
-	private SassCompiler initCompiler() {
-		SassCompiler compiler = new SassCompiler();
-		compiler.setEmbedSourceMapInCSS(this.embedSourceMapInCSS);
-		compiler.setEmbedSourceContentsInSourceMap(this.embedSourceContentsInSourceMap);
-		compiler.setGenerateSourceComments(this.generateSourceComments);
-		compiler.setGenerateSourceMap(this.generateSourceMap);
-		compiler.setIncludePaths(this.includePath);
-		compiler.setInputSyntax(this.inputSyntax);
-		compiler.setOmitSourceMappingURL(this.omitSourceMapingURL);
-		compiler.setOutputStyle(this.outputStyle);
-		compiler.setPrecision(this.precision);
-		return compiler;
-	}
-
-	private boolean processFile(Path inputRootPath, Path inputFilePath) throws IOException {
-		getLog().debug("Processing File " + inputFilePath);
-
-		Path relativeInputPath = inputRootPath.relativize(inputFilePath);
-
-		Path outputRootPath = this.outputPath.toPath();
-		Path outputFilePath = outputRootPath.resolve(relativeInputPath);
-		String fileExtension = getFileExtension();
-		outputFilePath = Paths.get(outputFilePath.toAbsolutePath().toString().replaceFirst("\\."+fileExtension+"$", ".css"));
-
-		Path sourceMapRootPath = Paths.get(this.sourceMapOutputPath);
-		Path sourceMapOutputPath = sourceMapRootPath.resolve(relativeInputPath);
-		sourceMapOutputPath = Paths.get(sourceMapOutputPath.toAbsolutePath().toString().replaceFirst("\\.scss$", ".css.map"));
-
-
-		Output out;
-		try {
-			out = compiler.compileFile(
-					inputFilePath.toAbsolutePath().toString(),
-					outputFilePath.toAbsolutePath().toString(),
-					sourceMapOutputPath.toAbsolutePath().toString()
-			);
-		}
-		catch (CompilationException e) {
-			getLog().error(e.getMessage());
-			getLog().debug(e);
-			return false;
-		}
-
-		getLog().debug("Compilation finished.");
-
-		writeContentToFile(outputFilePath, out.getCss());
-		if (out.getSourceMap() != null) {
-			writeContentToFile(sourceMapOutputPath, out.getSourceMap());
-		}
-		return true;
-	}
-
-	private void writeContentToFile(Path outputFilePath, String content) throws IOException {
-		File f = outputFilePath.toFile();
-		f.getParentFile().mkdirs();
-		f.createNewFile();
-		OutputStreamWriter os = null;
-		try{
-			os = new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
-			os.write(content);
-			os.flush();
-		} finally {
-			if (os != null)
-				os.close();
-		}
-		getLog().debug("Written to: " + f);
-	}
 }

--- a/src/main/java/wrm/WatchMojo.java
+++ b/src/main/java/wrm/WatchMojo.java
@@ -1,0 +1,95 @@
+package wrm;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * Watch for changes in inputPath, then compile scss files to outputPath using
+ * includePaths
+ *
+ * @goal watch
+ */
+public class WatchMojo extends AbstractSassMojo {
+
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		validateConfig();
+		compiler = initCompiler();
+
+		inputPath = inputPath.replaceAll("\\\\", "/");
+
+		getLog().debug("Input Path=" + inputPath);
+		getLog().debug("Output Path=" + outputPath);
+
+		try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
+			Path root = project.getBasedir().toPath().resolve(Paths.get(inputPath));
+			registerAll(root, watcher);
+			getLog().info("Watching [" + inputPath + "]...");
+			try {
+				long lastModified = 0;
+				for (;;) {
+					WatchKey key = watcher.take();
+					for (WatchEvent<?> event : key.pollEvents()) {
+						if (event.kind() == OVERFLOW) {
+							continue;
+						}
+						Path modifiedFile = ((Path) key.watchable()).resolve((Path) event.context());
+						if (modifiedFile.toFile().lastModified() - lastModified > 1000) {
+							// Ignore multiple occurrences that are too close
+							// Usually caused by editors (where content is changed
+							// and then file attributes are changed)
+							getLog().debug(String.format(
+									"%s: %s", event.kind().name(), modifiedFile));
+							try {
+								compile();
+							} catch (Exception e) {
+								// ignore
+							}
+						}
+						lastModified = modifiedFile.toFile().lastModified();
+						break;
+					}
+					if (!key.reset()) {
+						break;
+					}
+				}
+			} catch (InterruptedException e) {
+				getLog().warn("Watch service interrupted");
+			}
+		} catch (IOException e) {
+			throw new MojoExecutionException("Exception while watching", e);
+		}
+	}
+
+	/**
+	 * Register the given directory, and all its sub-directories, with the
+	 * WatchService.
+	 */
+	private void registerAll(Path start, WatchService watcher) throws IOException {
+		// register directory and sub-directories
+		Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+				dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
Added a WatchMojo that watches for file changes and triggers a compile. I had to refactor common methods into an abstract base class and preserve CompilationMojo functionality. Now, there can be two goals: `libsass:compile` and `libsass:watch`.
