### PR TITLE
Fix #53. Add classpath/webjar support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,21 @@
 			<version>3.1.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator-core</artifactId>
+			<version>0.32</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<!--Required only to test ClasspathAwareImporter-->
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>susy</artifactId>
+			<version>2.1.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/wrm/AbstractSassMojo.java
+++ b/src/main/java/wrm/AbstractSassMojo.java
@@ -1,27 +1,20 @@
 package wrm;
 
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import io.bit3.jsass.CompilationException;
+import io.bit3.jsass.Output;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.project.MavenProject;
+import wrm.libsass.SassCompiler;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.project.MavenProject;
-
-import io.bit3.jsass.CompilationException;
-import io.bit3.jsass.Output;
-import wrm.libsass.SassCompiler;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public abstract class AbstractSassMojo extends AbstractMojo {
 
@@ -111,6 +104,13 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 	 * @parameter default-value="5"
 	 */
 	private int precision;
+	/**
+	 * Enables classpath aware importer which make possible to <tt>@import</tt>
+	 * files from classpath and WebJars.
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean enableClasspathAwareImporter;
 	/**
 	 * should fail the build in case of compilation errors.
 	 *
@@ -203,6 +203,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 		compiler.setOmitSourceMappingURL(this.omitSourceMapingURL);
 		compiler.setOutputStyle(this.outputStyle);
 		compiler.setPrecision(this.precision);
+		compiler.setEnableClasspathAwareImporter(this.enableClasspathAwareImporter);
 		return compiler;
 	}
 

--- a/src/main/java/wrm/libsass/ClasspathAwareImporter.java
+++ b/src/main/java/wrm/libsass/ClasspathAwareImporter.java
@@ -1,0 +1,69 @@
+package wrm.libsass;
+
+import io.bit3.jsass.importer.Import;
+import io.bit3.jsass.importer.Importer;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static wrm.libsass.Lookups.*;
+
+class ClasspathAwareImporter implements Importer {
+	private static final String SCSS_EXT = ".scss";
+	private static final String CSS_EXT = ".css";
+
+	private final WebJarTranslator webJarTranslator = new WebJarTranslator();
+
+	@Override
+	public Collection<Import> apply(String importStr, Import previous) {
+		URI base = previous.getAbsoluteUri();
+		URI uri = buildUri(importStr);
+		Optional<URI> uriCss = tryBuildUriCss(importStr);
+
+		Stream<Lookup> lookups = Stream.of(
+				() -> findLocalFile(base, addUnderscore(uri)),
+				() -> findLocalFile(base, uri),
+				() -> uriCss.map(u -> findLocalFile(base, u)).orElse(Optional.empty()),
+				() -> findResource(addUnderscore(uri)),
+				() -> findResource(uri),
+				() -> uriCss.map(Lookups::findResource).orElse(Optional.empty()),
+				() -> findResource(addUnderscore(base.resolve(uri))),
+				() -> findResource(base.resolve(uri)),
+				() -> uriCss.map(u -> findResource(base.resolve(u))).orElse(Optional.empty()),
+				() -> findWebJarResource(addUnderscore(uri), webJarTranslator),
+				() -> findWebJarResource(uri, webJarTranslator),
+				() -> uriCss.map(u -> findWebJarResource(u, webJarTranslator)).orElse(Optional.empty()));
+		Optional<Lookup.Result> lookupResult = lookups
+				.map(Lookup::run)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.findFirst();
+		return lookupResult
+				.map(r -> r.buildImport(importStr))
+				.map(Collections::singletonList)
+				.orElse(null);
+	}
+
+	private static URI buildUri(String importStr) {
+		String withExtension = importStr.endsWith(SCSS_EXT) ? importStr : importStr + SCSS_EXT;
+		return URI.create(withExtension);
+	}
+
+	private static Optional<URI> tryBuildUriCss(String importStr) {
+		return importStr.endsWith(SCSS_EXT)
+				? Optional.empty()
+				: Optional.of(URI.create(importStr + CSS_EXT));
+	}
+
+	private static URI addUnderscore(URI source) {
+		String sourceStr = source.toString();
+		int afterLastSlash = sourceStr.lastIndexOf("/") + 1;
+		String withUnderscore = new StringBuilder(sourceStr)
+				.insert(afterLastSlash, "_")
+				.toString();
+		return URI.create(withUnderscore);
+	}
+}

--- a/src/main/java/wrm/libsass/Lookup.java
+++ b/src/main/java/wrm/libsass/Lookup.java
@@ -1,0 +1,58 @@
+package wrm.libsass;
+
+import io.bit3.jsass.importer.Import;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.Scanner;
+
+@FunctionalInterface
+interface Lookup {
+	Optional<Result> run();
+
+	class Result {
+		private final String absoluteUri;
+		private final URL url;
+
+		private Result(String absoluteUri, URL url) {
+			this.absoluteUri = absoluteUri;
+			this.url = url;
+		}
+
+		static Result of(String absoluteUri, URL url) {
+			return new Result(absoluteUri, url);
+		}
+
+		static Result of(File file) {
+			try {
+				String absoluteUri = file.getPath();
+				URL url = file.toURI().toURL();
+				return new Result(absoluteUri, url);
+			} catch (MalformedURLException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		Import buildImport(String importUri) {
+			try {
+				String contents = read(url);
+				return new Import(importUri, absoluteUri, contents);
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		private static String read(URL url) {
+			try (Scanner scanner = new Scanner(url.openStream(), StandardCharsets.UTF_8.name())) {
+				return scanner.useDelimiter("\\A").next();
+			} catch (IOException e) {
+				throw new RuntimeException("Cannot read the url: " + url, e);
+			}
+		}
+	}
+}

--- a/src/main/java/wrm/libsass/Lookups.java
+++ b/src/main/java/wrm/libsass/Lookups.java
@@ -1,0 +1,45 @@
+package wrm.libsass;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.Optional;
+
+class Lookups {
+	static Optional<Lookup.Result> findLocalFile(URI base, URI uri) {
+		String pathname = base.resolve(uri).toString();
+		File file = new File(pathname);
+		return file.exists()
+				? Optional.of(Lookup.Result.of(file))
+				: Optional.empty();
+	}
+
+	static Optional<Lookup.Result> findResource(URI uri) {
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		URL url = classLoader.getResource(uri.toString());
+		return Optional.ofNullable(url).flatMap(Lookups::toResult);
+	}
+
+	private static Optional<Lookup.Result> toResult(URL url) {
+		switch (url.getProtocol()) {
+			case "file":
+				return Optional.of(Lookup.Result.of(url.toString(), url));
+			case "jar":
+				try {
+					JarURLConnection jarUrlConnection = (JarURLConnection) url.openConnection();
+					String name = jarUrlConnection.getEntryName();
+					return Optional.of(Lookup.Result.of(name, url));
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			default:
+				return Optional.empty();
+		}
+	}
+
+	static Optional<Lookup.Result> findWebJarResource(URI uri, WebJarTranslator translator) {
+		return translator.translate(uri).flatMap(Lookups::findResource);
+	}
+}

--- a/src/main/java/wrm/libsass/SassCompiler.java
+++ b/src/main/java/wrm/libsass/SassCompiler.java
@@ -1,13 +1,13 @@
 package wrm.libsass;
 
-import static wrm.libsass.SassCompiler.InputSyntax.sass;
+import io.bit3.jsass.CompilationException;
+import io.bit3.jsass.Options;
+import io.bit3.jsass.Output;
 
 import java.io.File;
 import java.net.URI;
 
-import io.bit3.jsass.CompilationException;
-import io.bit3.jsass.Options;
-import io.bit3.jsass.Output;
+import static wrm.libsass.SassCompiler.InputSyntax.sass;
 
 public class SassCompiler {
 
@@ -20,6 +20,7 @@ public class SassCompiler {
 	private boolean embedSourceContentsInSourceMap;
 	private SassCompiler.InputSyntax inputSyntax;
 	private int precision;
+	private boolean enableClasspathAwareImporter;
 
 	/**
 	 * All paths passed to this method must be relative to the same directory.
@@ -72,6 +73,11 @@ public class SassCompiler {
 			opt.setSourceMapEmbed(false);
 			opt.setOmitSourceMapUrl(true);
 		}
+
+		if (enableClasspathAwareImporter) {
+			opt.getImporters().add(new ClasspathAwareImporter());
+		}
+
 		return opt;
 	}
 
@@ -119,6 +125,9 @@ public class SassCompiler {
 		this.precision = precision;
 	}
 
+	public void setEnableClasspathAwareImporter(boolean enableClasspathAwareImporter) {
+		this.enableClasspathAwareImporter = enableClasspathAwareImporter;
+	}
 
 	public static enum InputSyntax {
 		sass, scss

--- a/src/main/java/wrm/libsass/WebJarTranslator.java
+++ b/src/main/java/wrm/libsass/WebJarTranslator.java
@@ -1,0 +1,37 @@
+package wrm.libsass;
+
+import org.webjars.WebJarAssetLocator;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.toMap;
+
+class WebJarTranslator {
+	private static final Pattern WEBJAR_PATTERN = Pattern.compile(WebJarAssetLocator.WEBJARS_PATH_PREFIX + "/([^/]+)/([^/]+)/(.*)");
+
+	private final Map<String, String> index;
+
+	WebJarTranslator() {
+		index = new WebJarAssetLocator().getFullPathIndex()
+				.values()
+				.stream()
+				.map(WEBJAR_PATTERN::matcher)
+				.filter(Matcher::matches)
+				.collect(toMap(WebJarTranslator::convertMatchedPath, m -> m.group(0)));
+	}
+
+	private static String convertMatchedPath(Matcher matcher) {
+		String name = matcher.group(1);
+		String path = matcher.group(3);
+		return name + "/" + path;
+	}
+
+	Optional<URI> translate(URI uri) {
+		String fullPath = index.get(uri.toString());
+		return fullPath == null ? Optional.empty() : Optional.of(URI.create(fullPath));
+	}
+}

--- a/src/test/java/test/SassCompilerTest.java
+++ b/src/test/java/test/SassCompilerTest.java
@@ -2,15 +2,11 @@ package test;
 
 import io.bit3.jsass.Output;
 import io.bit3.jsass.OutputStyle;
-import wrm.libsass.SassCompiler;
-
 import org.junit.Before;
 import org.junit.Test;
+import wrm.libsass.SassCompiler;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link SassCompiler}.
@@ -34,6 +30,7 @@ public class SassCompilerTest {
 		compiler.setGenerateSourceComments(false);
 		compiler.setGenerateSourceMap(true);
 		compiler.setIncludePaths(null);
+		compiler.setEnableClasspathAwareImporter(true);
 	}
 
 	@Test
@@ -125,6 +122,17 @@ public class SassCompilerTest {
 		compile("/precision.scss");
 
 		assertCssContains(".something{padding:0 0.8em .7142857143 0.8em}");
+	}
+
+	@Test
+	public void testWebJar() throws Exception {
+		compile("/webjar-test.scss");
+
+		assertCssContains("*, *::before, *::after {\n" +
+				"  -moz-box-sizing: border-box;\n" +
+				"  -webkit-box-sizing: border-box;\n" +
+				"  box-sizing: border-box;\n" +
+				"}");
 	}
 
 	private void compile(String file) throws Exception {

--- a/src/test/java/wrm/libsass/WebJarTranslatorTest.java
+++ b/src/test/java/wrm/libsass/WebJarTranslatorTest.java
@@ -1,0 +1,20 @@
+package wrm.libsass;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class WebJarTranslatorTest {
+	@Test
+	public void testTranslate() throws Exception {
+		WebJarTranslator translator = new WebJarTranslator();
+
+		URI importUri = URI.create("susy/sass/susy/_math.scss");
+		Optional<URI> fullUri = translator.translate(importUri);
+		Optional<URI> expectedUri = Optional.of(URI.create("META-INF/resources/webjars/susy/2.1.1/sass/susy/_math.scss"));
+
+		Assert.assertEquals(expectedUri, fullUri);
+	}
+}

--- a/src/test/resources/webjar-test.scss
+++ b/src/test/resources/webjar-test.scss
@@ -1,0 +1,3 @@
+@import 'susy/sass/susy';
+
+@include border-box-sizing;


### PR DESCRIPTION
I have tested it on Linux only, but classpath aware importer is disabled by default, so it shouldn't break anything.
Also, I'm an absolute newbie in Maven plugin development, so I don't know a proper way to give access to project dependencies to plugin. So, for now, this feature works only if you explicitly specify required webjar as plugin dependency in POM.