### PR TITLE
Add project dependencies to plugin classloader

### DIFF
--- a/src/main/java/wrm/AbstractSassMojo.java
+++ b/src/main/java/wrm/AbstractSassMojo.java
@@ -117,7 +117,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 	 *
 	 * @parameter default-value="false"
 	 */
-	private boolean enableClasspathAwareImporter;	
+	private boolean enableClasspathAwareImporter;
 	/**
 	 * should fail the build in case of compilation errors.
 	 *
@@ -186,7 +186,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 	}
 
 	protected void validateConfig() {
-	   setCompileClasspath();
+		setCompileClasspath();
 		if (!generateSourceMap) {
 			if (embedSourceMapInCSS) {
 				getLog().warn("embedSourceMapInCSS=true is ignored. Cause: generateSourceMap=false");
@@ -201,26 +201,26 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 	}
 
 	private void setCompileClasspath() {
-	  try {
-	    Set<URL> urls = new HashSet<>();
-	    List<String> elements = project.getCompileClasspathElements();
-	    for (String element : elements) {
-	      urls.add(new File(element).toURI().toURL());
-	    }
+		try {
+			Set<URL> urls = new HashSet<>();
+			List<String> elements = project.getCompileClasspathElements();
+			for (String element : elements) {
+				urls.add(new File(element).toURI().toURL());
+			}
 
-	    ClassLoader contextClassLoader = URLClassLoader.newInstance(
-	      urls.toArray(new URL[0]),
-	      Thread.currentThread().getContextClassLoader());
+			ClassLoader contextClassLoader = URLClassLoader.newInstance(
+					urls.toArray(new URL[0]),
+					Thread.currentThread().getContextClassLoader());
 
-	    Thread.currentThread().setContextClassLoader(contextClassLoader);
-	    
-	  } catch (DependencyResolutionRequiredException e) {
-	    throw new RuntimeException(e);
-	  } catch (MalformedURLException e) {
-	    throw new RuntimeException(e);
-	  }
+			Thread.currentThread().setContextClassLoader(contextClassLoader);
+
+		} catch (DependencyResolutionRequiredException e) {
+			throw new RuntimeException(e);
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
 	}
-	  
+
 	protected SassCompiler initCompiler() {
 		SassCompiler compiler = new SassCompiler();
 		compiler.setEmbedSourceMapInCSS(this.embedSourceMapInCSS);

--- a/src/main/java/wrm/CompilationMojo.java
+++ b/src/main/java/wrm/CompilationMojo.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.MojoFailureException;
  *
  * @goal compile
  * @phase generate-resources
+ * @requiresDependencyResolution compile
  */
 public class CompilationMojo extends AbstractSassMojo {
 

--- a/src/main/java/wrm/libsass/WebJarTranslator.java
+++ b/src/main/java/wrm/libsass/WebJarTranslator.java
@@ -16,7 +16,8 @@ class WebJarTranslator {
 	private final Map<String, String> index;
 
 	WebJarTranslator() {
-		index = new WebJarAssetLocator().getFullPathIndex()
+		index = WebJarAssetLocator.getFullPathIndex(Pattern.compile(".*"),
+		    Thread.currentThread().getContextClassLoader())
 				.values()
 				.stream()
 				.map(WEBJAR_PATTERN::matcher)

--- a/src/main/java/wrm/libsass/WebJarTranslator.java
+++ b/src/main/java/wrm/libsass/WebJarTranslator.java
@@ -17,7 +17,7 @@ class WebJarTranslator {
 
 	WebJarTranslator() {
 		index = WebJarAssetLocator.getFullPathIndex(Pattern.compile(".*"),
-		    Thread.currentThread().getContextClassLoader())
+				Thread.currentThread().getContextClassLoader())
 				.values()
 				.stream()
 				.map(WEBJAR_PATTERN::matcher)


### PR DESCRIPTION
Hi,

regarding the pull request #54 from @flipp5b:

> Also, I'm an absolute newbie in Maven plugin development, so I don't know a proper way to give access to project dependencies to plugin. So, for now, this feature works only if you explicitly specify required webjar as plugin dependency in POM.

It is quite easy to fix, I created a new classloader and attached it to the thread. All resource based lookups need to use this classloader (WebJarTranslator constructor and Lookups.findResource).

Greetings,
Stefan