### PR TITLE
removed os specific file separator

### DIFF
--- a/src/main/java/wrm/libsass/SassCompiler.java
+++ b/src/main/java/wrm/libsass/SassCompiler.java
@@ -49,7 +49,7 @@ public class SassCompiler {
 		Options opt = new Options();
 
 		if(includePaths != null) {
-			for (String path : includePaths.split(File.pathSeparator)) {
+			for (String path : includePaths.split(";")) {
 				opt.getIncludePaths().add(new File(path));
 			}
 		}


### PR DESCRIPTION
File.pathSeparator is for linux ':' and not ';'.

Developer machines running on Windows and the build server is running on Linux. I'm open to discuss other solutions, but we need to make it possible to run on both os types with the same pom.xml.